### PR TITLE
Use config.php to store server configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 img/stu_profile/
 img/staff_profile/
 img/slips/
+config.php

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Kasalong
+
+
+## Configuration
+
+Create `php/config.php`. Refer to `php/config.php.example`, or simply copy it:
+
+```sh
+cp php/config.php.example php/config.php
+```
+
+Edit `php/config.php` accordingly. Make sure to specify the following variables:
+- `$servername` : server hostname
+- `$username` : MySQL user name
+- `$password` : MySQL password
+- `$dbname` : MySQL database name
+
+<!-- TODO: Add more sections/table of contents -->

--- a/php/config.php.example
+++ b/php/config.php.example
@@ -1,0 +1,6 @@
+<?php
+    $servername = "127.0.0.1";
+    $username = "root";
+    $password = "";
+    $dbname = "kasalong";
+?>

--- a/php/connect.php
+++ b/php/connect.php
@@ -1,8 +1,5 @@
 <?php
-    $servername = "localhost";
-    $username = "root";
-    $password = "";
-    $dbname = "kasalong";
+    include("config.php");
 
     $conn = new mysqli($servername,$username,$password,$dbname);
     if($conn->connect_error){

--- a/php/createdb.php
+++ b/php/createdb.php
@@ -1,8 +1,5 @@
 <?php
-    $servername = "localhost";
-    $username = "root";
-    $password = "";
-    $dbname = "kasalong";
+    include("config.php");
 
     $conn = new mysqli($servername,$username,$password);
 


### PR DESCRIPTION
Instead of hard coding server parameters, use a separate file to store local configurations and `include` it when needed.

Also, I used `127.0.0.1` instead of `localhost` to avoid hostname resolution issues.